### PR TITLE
git ignore追加　

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,36 @@
+# https://github.com/github/gitignore/blob/main/Android.gitignore
+
 # Default ignored files
 /shelf/
 /workspace.xml
+
+# Gradle files
+.gradle/
+build/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Log/OS Files
+*.log
+
+# Android Studio generated files and folders
+captures/
+.externalNativeBuild/
+.cxx/
+*.apk
+output.json
+
+# IntelliJ
+*.iml
+.idea/
+
+# Keystore files
+*.jks
+*.keystore
+
+# Google Services (e.g. APIs or Firebase)
+google-services.json
+
+# Android Profiling
+*.hprof


### PR DESCRIPTION
git が公表している[git ignoreのレンプレート](https://github.com/github/gitignore/blob/main/Android.gitignore)をもとに作成しました。