### PR TITLE
Introduce hilt

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="15" />
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'kotlin-kapt'
     id 'kotlin-parcelize'
     id 'androidx.navigation.safeargs.kotlin'
+    id 'dagger.hilt.android.plugin'
 }
 
 android {
@@ -54,6 +55,14 @@ dependencies {
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
     implementation 'io.ktor:ktor-client-android:1.6.4'
+
+    //Hilt
+    implementation "com.google.dagger:hilt-android:2.40.5"
+    kapt "com.google.dagger:hilt-android-compiler:2.40.5"
+    implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03'
+    kapt 'androidx.hilt:hilt-compiler:1.0.0'
+    implementation 'androidx.hilt:hilt-navigation-fragment:1.0.0'
+    implementation 'androidx.hilt:hilt-work:1.0.0'
 
     implementation 'io.coil-kt:coil:1.3.2'
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/AppModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/AppModule.kt
@@ -1,0 +1,10 @@
+package jp.co.yumemi.android.code_check.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+}

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,9 @@ buildscript {
         classpath 'com.android.tools.build:gradle:7.0.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5"
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.40.5'
+
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
依存性注入を行うためのライブラリとして、Hilt を導入
理由
テストを行いやすくするため。開発を円滑に進めるため。
なぜhiltか
依存性注入について、現状公式が押し出しているのがHiltであり、他のjetnpack ライブラリとも親和性が高いため