### PR TITLE
Introduce hilt

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/App.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/App.kt
@@ -1,0 +1,8 @@
+package jp.co.yumemi.android.code_check
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class App : Application(){
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
@@ -12,8 +12,10 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.*
+import dagger.hilt.android.AndroidEntryPoint
 import jp.co.yumemi.android.code_check.databinding.FragmentOneBinding
 
+@AndroidEntryPoint
 class OneFragment : Fragment(R.layout.fragment_one) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneViewModel.kt
@@ -6,6 +6,7 @@ package jp.co.yumemi.android.code_check
 import android.content.Context
 import android.os.Parcelable
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.android.*
@@ -19,6 +20,7 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.*
 
+@HiltViewModel
 class OneViewModel(
     val context: Context
 ) : ViewModel() {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/TwoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/TwoFragment.kt
@@ -9,9 +9,11 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import coil.load
+import dagger.hilt.android.AndroidEntryPoint
 import jp.co.yumemi.android.code_check.TopActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.code_check.databinding.FragmentTwoBinding
 
+@AndroidEntryPoint
 class TwoFragment : Fragment(R.layout.fragment_two) {
 
     private val args: TwoFragmentArgs by navArgs()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/topActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/topActivity.kt
@@ -4,8 +4,10 @@
 package jp.co.yumemi.android.code_check
 
 import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
 import java.util.*
 
+@AndroidEntryPoint
 class TopActivity : AppCompatActivity(R.layout.activity_top) {
 
     companion object {


### PR DESCRIPTION
依存性注入を行うためのライブラリとして、Hilt を導入
理由
テストを行いやすくするため。開発を円滑に進めるため。
なぜhiltか
依存性注入について、現状公式が押し出しているのがHiltであり、他のjetnpack ライブラリとも親和性が高いため