### PR TITLE
Introduce logger

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,4 +69,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+
+    //timber
+    implementation 'com.jakewharton.timber:timber:5.0.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     
     <application
+        android:name=".App"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/App.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/App.kt
@@ -2,7 +2,17 @@ package jp.co.yumemi.android.code_check
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
+import timber.log.Timber
 
 @HiltAndroidApp
 class App : Application(){
+    override fun onCreate() {
+        super.onCreate()
+        configureTimber()
+    }
+    private fun configureTimber() {
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
+    }
 }


### PR DESCRIPTION
loggerライブラリとしてtimberを導入
理由
標準のprintクラスは記述する量が多く、煩雑なため
なぜtimberか
公式が押し出していること。そして実際に使ってみたところ簡単に記述でき手に馴染んだため。