### PR TITLE
画面の横向きを非対応にしました。

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AndroidEngineerCodeCheck"
-        android:fullBackupContent="@xml/backup_descriptor">
+        android:fullBackupContent="@xml/backup_descriptor"
+        android:screenOrientation="portrait">
         <activity
             android:name="jp.co.yumemi.android.code_check.TopActivity"
             android:exported="true">


### PR DESCRIPTION
理由
今回のアプリのUIは画面回転を特に必要としないと考えて、慣れていない画面回転に対応するコストと得られるUIの変化を比べたときに、実装をする必要がないと判断しました。