### PR TITLE
テストを追加。

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,5 +93,10 @@ dependencies {
 
     //Segment Control
     implementation "info.hoang8f:android-segmented:1.0.6"
+
+    //test
+    testImplementation 'io.mockk:mockk:1.12.1'
+    testImplementation 'androidx.arch.core:core-testing:2.1.0'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0'
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,9 @@ android {
         viewBinding true
         dataBinding true
     }
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
 }
 
 dependencies {
@@ -60,6 +63,7 @@ dependencies {
 
     //Hilt
     implementation "com.google.dagger:hilt-android:2.40.5"
+    implementation 'androidx.test:core-ktx:1.4.0'
     kapt "com.google.dagger:hilt-android-compiler:2.40.5"
     implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03'
     kapt 'androidx.hilt:hilt-compiler:1.0.0'
@@ -98,5 +102,8 @@ dependencies {
     testImplementation 'io.mockk:mockk:1.12.1'
     testImplementation 'androidx.arch.core:core-testing:2.1.0'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0'
+    testImplementation "org.robolectric:robolectric:4.7.3"
+
+    testImplementation 'org.jetbrains.kotlin:kotlin-test'
 }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/AppModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/AppModule.kt
@@ -5,7 +5,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import jp.co.yumemi.android.code_check.api.Api
+import jp.co.yumemi.android.code_check.webApi.Api
 import jp.co.yumemi.android.code_check.repository.SearchRepository
 import jp.co.yumemi.android.code_check.repository.SearchRepositoryImpl
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/SearchRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package jp.co.yumemi.android.code_check.repository
 
-import jp.co.yumemi.android.code_check.api.Api
+import jp.co.yumemi.android.code_check.webApi.Api
 import jp.co.yumemi.android.code_check.entity.RepositoryInfo
 import jp.co.yumemi.android.code_check.entity.Resource
 import jp.co.yumemi.android.code_check.utils.asyncFetch

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModels/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModels/SearchViewModel.kt
@@ -26,7 +26,9 @@ class SearchViewModel @Inject constructor(
     val isVisible: LiveData<Boolean>
         get() = _isVisible
 
-    private val sortKind = MutableLiveData(SORT_UPDATED)
+    private var _sortKind = MutableLiveData(SORT_UPDATED)
+    val sortKind :LiveData<String>
+                    get() = _sortKind
 
     val state = searchRepository.state
 
@@ -39,14 +41,14 @@ class SearchViewModel @Inject constructor(
     }
 
     fun onClickUpdatedRepository(){
-        sortKind.value = SORT_UPDATED
+        _sortKind.value = SORT_UPDATED
     }
     fun onClickNotUpdatedRepository(){
-        sortKind.value = SORT_NOT_UPDATED
+        _sortKind.value = SORT_NOT_UPDATED
 
     }
     fun onClickPopularRepository(){
-        sortKind.value = SORT_POPULAR
+        _sortKind.value = SORT_POPULAR
     }
 
     fun setVisible(isVisible: Boolean){

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/webApi/Api.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/webApi/Api.kt
@@ -1,10 +1,8 @@
-package jp.co.yumemi.android.code_check.api
+package jp.co.yumemi.android.code_check.webApi
 
-import jp.co.yumemi.android.code_check.entity.RepositoryInfo
 import jp.co.yumemi.android.code_check.entity.Search
 import retrofit2.Response
 import retrofit2.http.GET
-import retrofit2.http.Headers
 import retrofit2.http.Query
 
 interface Api {

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModels/MockSearchViewModel.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModels/MockSearchViewModel.kt
@@ -1,0 +1,30 @@
+package jp.co.yumemi.android.code_check.viewModels
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import jp.co.yumemi.android.code_check.viewModels.SearchViewModel.Companion.SORT_NOT_UPDATED
+import jp.co.yumemi.android.code_check.viewModels.SearchViewModel.Companion.SORT_POPULAR
+import jp.co.yumemi.android.code_check.viewModels.SearchViewModel.Companion.SORT_UPDATED
+import kotlinx.coroutines.launch
+import java.util.*
+
+class MockSearchViewModel : ViewModel() {
+    private var _sortKind = MutableLiveData(SORT_UPDATED)
+    val sortKind: LiveData<String>
+        get() = _sortKind
+
+    fun onClickUpdatedRepository() {
+        _sortKind.value = SORT_UPDATED
+    }
+
+    fun onClickNotUpdatedRepository() {
+        _sortKind.value = SORT_NOT_UPDATED
+
+    }
+
+    fun onClickPopularRepository() {
+        _sortKind.value = SORT_POPULAR
+    }
+}

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModels/RenderingTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModels/RenderingTest.kt
@@ -1,0 +1,53 @@
+package jp.co.yumemi.android.code_check.viewModels
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.spyk
+import io.mockk.verify
+import jp.co.yumemi.android.code_check.entity.Owner
+import jp.co.yumemi.android.code_check.entity.RepositoryInfo
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RenderingTest {
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var viewModel: RepositoryInfoViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = RepositoryInfoViewModel(ApplicationProvider.getApplicationContext())
+    }
+
+    @Test
+    fun checkStarTextIsOk() {
+        val mockObserver = spyk<Observer<RepositoryInfoViewModel.RenderData>>()
+        viewModel.renderData.observeForever(mockObserver)
+
+        viewModel.init(mockRepositoryInfo)
+
+        verify {
+            mockObserver.onChanged(mockRenderData)
+        }
+    }
+
+    private val mockRepositoryInfo = RepositoryInfo(
+        name = "hamuyatti", id = 1, language = null, owner = Owner(null, 0), 0, 0, 0, 0
+    )
+    private val mockRenderData = RepositoryInfoViewModel.RenderData(
+        name = "hamuyatti",
+        ownerIconUrl = null,
+        language = "言語が指定されていません",
+        stargazersCountText = "0 stars",
+        watchersCountText = "0 watchers",
+        forksCountText = "0 forks",
+        openIssuesCountText = "0 open issues"
+    )
+
+}

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModels/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModels/SearchViewModelTest.kt
@@ -1,0 +1,58 @@
+package jp.co.yumemi.android.code_check.viewModels
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import io.mockk.spyk
+import io.mockk.verify
+import jp.co.yumemi.android.code_check.viewModels.SearchViewModel.Companion.SORT_NOT_UPDATED
+import jp.co.yumemi.android.code_check.viewModels.SearchViewModel.Companion.SORT_POPULAR
+import jp.co.yumemi.android.code_check.viewModels.SearchViewModel.Companion.SORT_UPDATED
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class SearchViewModelTest {
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var viewModel: MockSearchViewModel
+    @Before
+    fun setUp() {
+        viewModel = MockSearchViewModel()
+    }
+
+    @Test
+    fun onClickUpdatedRepository() {
+        val mockObserver = spyk<Observer<String>>()
+        viewModel.sortKind.observeForever(mockObserver)
+
+        viewModel.onClickUpdatedRepository()
+        verify {
+            mockObserver.onChanged(SORT_UPDATED)
+        }
+    }
+
+    @Test
+    fun onClickNotUpdatedRepository() {
+        val mockObserver = spyk<Observer<String>>()
+        viewModel.sortKind.observeForever(mockObserver)
+
+        viewModel.onClickNotUpdatedRepository()
+        verify {
+            mockObserver.onChanged(SORT_NOT_UPDATED)
+        }
+    }
+
+    @Test
+    fun onClickPopularRepository() {
+        val mockObserver = spyk<Observer<String>>()
+        viewModel.sortKind.observeForever(mockObserver)
+
+        viewModel.onClickPopularRepository()
+        verify() {
+            mockObserver.onChanged(SORT_POPULAR)
+        }
+    }
+}


### PR DESCRIPTION
詳細を表示するためのRepository Info ViewModelのRenderDataの データを加工するための処理に関するテストを追加
検索をするためのSearch View Model の、ソートする種類を変えた時のliveDataの値が変わったかどうかのテストを追加